### PR TITLE
Fix banner height issues and improve print layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,27 @@ the next section to configure your site and add banner images on your pages.
       href: # Optional, a link on the caption
     ```
 
+## Customise banner height
+
+Banner heights are controlled by CSS custom properties. Override them with a custom CSS file in
+your `/assets/css/` folder (see the CSS customisation entry in Troubleshooting / FAQ):
+
+| Variable | Default | Description |
+|---|---|---|
+| `--summary__banner-min-height` | `10rem` | Minimum height of banners on list/homepage cards |
+| `--summary__banner-max-height` | `30rem` | Maximum height of banners on list/homepage cards |
+| `--header--main-min-height` | `0rem` | Minimum height of the full-page header banner |
+
+Example — taller summary cards with a minimum hero height:
+
+```css
+:root {
+  --summary__banner-min-height: 20rem;
+  --summary__banner-max-height: 40rem;
+  --header--main-min-height: 50rem;
+}
+```
+
 ## Troubleshooting / FAQ
 
 - I can't generate the site.

--- a/assets/css/blogpaper.scss
+++ b/assets/css/blogpaper.scss
@@ -50,6 +50,7 @@
 
   --header--main-max-width: 75rem;
   --header--main-margin-bottom: 3rem;
+  --header--main-min-height: 0rem;
   --header--main-padding-bottom: 4rem;
   --header--main-color-text: #fff;
   --header--main-color-text-rgb: #{to-rgb(#fff)};
@@ -59,6 +60,7 @@
   --content-max-width: 75rem;
 
   --summary-margin-bottom: calc(3 * var(--header--main-margin-bottom));
+  --summary__banner-min-height: 10rem;
   --summary__banner-max-height: 30rem;
   --summary__banner-margin-bottom: var(--container-padding);
   --summary__content-margin-top: var(--container-padding);
@@ -260,6 +262,7 @@ a {
 .header--main {
   position: relative;
   margin-bottom: var(--header--main-margin-bottom);
+  min-height: var(--header--main-min-height);
   padding-top: var(--nav-height);
   padding-bottom: var(--header--main-padding-bottom);
   background: var(--header--main-color-background);
@@ -316,8 +319,14 @@ a {
 
   .banner {
     margin-bottom: var(--summary__banner-margin-bottom);
+    min-height: var(--summary__banner-min-height);
     max-height: var(--summary__banner-max-height);
     overflow: hidden;
+
+    img {
+      min-height: var(--summary__banner-min-height);
+      object-fit: cover;
+    }
   }
 
   &__content {
@@ -424,9 +433,11 @@ a {
     background: none;
     color: inherit;
     padding-top: 0;
+    padding-bottom: 0;
   }
 
-  .header--main .banner {
+  .header--main .banner,
+  .summary .banner {
     display: none;
   }
 

--- a/exampleSite/netlify.toml
+++ b/exampleSite/netlify.toml
@@ -1,0 +1,7 @@
+[build]
+  command = "hugo --minify"
+  publish = "public"
+
+[build.environment]
+  HUGO_VERSION = "0.128.0"
+  HUGO_EXTENDED = "true"


### PR DESCRIPTION
- Issue #7: enforce minimum summary banner height (10rem) with
  object-fit: cover so short images display consistently
- Issue #6: expose --summary__banner-min-height and
  --header--main-min-height CSS variables; document them in README
- Issue #4: zero out header padding-bottom in print and suppress
  decorative summary banners in print media
- Issue #13: add exampleSite/netlify.toml pinning Hugo ≥ 0.128
  extended to prevent version-mismatch deploy failures

https://claude.ai/code/session_01QPT4QcT1E4cLniL7k3Eqku